### PR TITLE
Slight tweak to log indentation

### DIFF
--- a/srcs/CommonFunctions.cpp
+++ b/srcs/CommonFunctions.cpp
@@ -16,7 +16,7 @@
 #define Info(msg, color)	(info(std::stringstream("") << msg, color))
 
 void	printBody(const std::string &contentType, const std::string &body, const u8 color) {
-	Info("\t\tContent-Type: " << contentType << " {", color);
+	Info("    Content-Type: " << contentType << " {", color);
 	std::cerr << "\x1b[1;38;5;" << static_cast<i32>(color) << "m";
 	for (const char &c : body) {
 		if (isprint(c) || c == '\n')

--- a/srcs/http/Request.cpp
+++ b/srcs/http/Request.cpp
@@ -109,17 +109,17 @@ void	Request::append(const std::string &reqData) {
 		Info("\nInvalid request received: Error " << this->_errorCode);
 	else {
 		info("\nNew request received:", COLOR_REQUEST);
-		Info("\tMethod:  " << this->_method);
-		Info("\tURI:     " << this->_uri);
-		Info("\tVersion: " << this->_version);
+		Info("  Method:  " << this->_method);
+		Info("  URI:     " << this->_uri);
+		Info("  Version: " << this->_version);
 #ifdef __DEBUG_REQ_SHOW_HEADERS
-		info("\n\tHeaders:", COLOR_REQUEST);
+		info("\n  Headers:", COLOR_REQUEST);
 		for (const auto &field : this->_headers)
-			Info("\t\t" << field.first << ": " << field.second);
+			Info("    " << field.first << ": " << field.second);
 #endif /* __DEBUG_REQ_SHOW_HEADERS */
 #ifdef __DEBUG_REQ_SHOW_BODY
 		if (this->_body.size() != 0) {
-			info("\n\tBody:", COLOR_REQUEST);
+			info("\n  Body:", COLOR_REQUEST);
 			printBody(this->_contentType, this->_body, COLOR_REQUEST);
 		}
 #endif /* __DEBUG_REQ_SHOW_BODY */

--- a/srcs/http/Response.cpp
+++ b/srcs/http/Response.cpp
@@ -133,17 +133,17 @@ void  Response::prepareResponse() {
 	handleResponse();
 	auto msg = statusMessages.find(_statusCode);
 	info("\nResponse prepared:", COLOR_RESPONSE);
-	info("\tVersion:        HTTP/1.1", COLOR_RESPONSE);
-	Info("\tStatus code:    " << _statusCode);
-	Info("\tStatus message: " << ((msg != statusMessages.end()) ? msg->second : "Unknown"));
+	info("  Version:        HTTP/1.1", COLOR_RESPONSE);
+	Info("  Status code:    " << _statusCode);
+	Info("  Status message: " << ((msg != statusMessages.end()) ? msg->second : "Unknown"));
 #ifdef __DEBUG_RES_SHOW_HEADERS
-	info("\n\tHeaders: ", COLOR_RESPONSE);
+	info("\n  Headers: ", COLOR_RESPONSE);
 	for (const auto &field : _headers)
-		Info("\t\t" << field.first << ": " << field.second);
+		Info("    " << field.first << ": " << field.second);
 #endif /* __DEBUG_RES_SHOW_HEADERS */
 #ifdef __DEBUG_RES_SHOW_BODY
 	if (_body.size() != 0) {
-		info("\n\tBody: ", COLOR_RESPONSE);
+		info("\n  Body: ", COLOR_RESPONSE);
 		printBody(_headers["Content-Type"], _body, COLOR_RESPONSE);
 	}
 #endif /* __DEBUG_RES_SHOW_BODY */


### PR DESCRIPTION
Replace all tabs with 2 spaces to be in line with the scheme for displaying server configs.